### PR TITLE
Fix remaining preceeding typos in docs

### DIFF
--- a/docs/standards/cwg.txt
+++ b/docs/standards/cwg.txt
@@ -460,7 +460,7 @@
           CORE WAR GUIDELINES                                           9.
 
           The instruction  currently being  executed would  always be dis-
-          played at the bottom of the screen, along with the preceeding 23
+          played at the bottom of the screen, along with the preceding 23
           instructions (on a 24-line screen). The information for the dis-
           play might  be generated  as each instruction is interpreted and
           the values of the  various fields  are determined.  A subroutine

--- a/newsletters/pushoff/93-06-22.txt
+++ b/newsletters/pushoff/93-06-22.txt
@@ -139,7 +139,7 @@ avamp    mov bomb,<-100
          sub @avamp,<avamp
 
 which bombs along sequentially (prequentially?) until avamp is
-pointing at a fang.  Then it subtracts the fang from the preceeding
+pointing at a fang.  Then it subtracts the fang from the preceding
 location (probably dat 0,0) to reverse the sign on the fang-location,
 and starts bombing every other location from the resulting offset.
 This code-fragment, all by itself, will beat Sucker 4&5 at least 90%


### PR DESCRIPTION
## Summary

- fix remaining `preceeding` typos in documentation/newsletter text
- keep the already-correct loop/if sentence unchanged

Fixes #16.

## Test Plan

- `rg -n "preceeding|Preceeding|PRECEEDING" .`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed spelling errors in documentation and newsletter content for improved accuracy and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->