### PR TITLE
Fix @ symbol label in docs

### DIFF
--- a/doc/pmars.6
+++ b/doc/pmars.6
@@ -959,7 +959,7 @@ most of these symbols have a different meaning:
  PC1.. are 0
 .fi
 .PP
-Preceding a command with the character '@' (ampersand)  will suppress
+Preceding a command with the character '@' (at sign)    will suppress
 its screen output, but not output to a logfile.
 Preceding a command with '&' will suppress both screen and logfile output,
 which is useful if you are only interested in the "side-effects" of a 

--- a/doc/pmars.txt
+++ b/doc/pmars.txt
@@ -698,7 +698,7 @@ CDB DEBUGGER
         PC    is 0.
         PC1.. are 0
 
-       Preceding a command with the character '@' (ampersand)   will  suppress
+       Preceding a command with the character '@' (at sign)     will  suppress
        its  screen  output,  but not output to a logfile.  Preceding a command
        with '&' will suppress both screen and logfile output, which is  useful
        if  you  are  only  interested  in  the  "side-effects"  of  a command.


### PR DESCRIPTION
## Summary

- replace the incorrect `@` label from `ampersand` to `at sign` in the pMARS docs
- keep the separate `&` ampersand description unchanged

Fixes #14.

## Test Plan

- `rg -n "@.*ampersand|ampersand.*@" .`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected CDB command prefix documentation to accurately reflect that the `@` prefix suppresses screen output only while allowing logfile output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->