### PR TITLE
Fix #19: Correct 'predrecement' typo to 'predecrement' in docs

### DIFF
--- a/doc/pmars.6
+++ b/doc/pmars.6
@@ -391,7 +391,7 @@ instead of the B-field as the pointer for indirection:
 .LP
 * - indirect using A-field
 .LP
-{ - predrecement indirect using A-field
+{ - predecrement indirect using A-field
 .LP
 } - postincrement indirect using A-field
 .PP

--- a/doc/pmars.txt
+++ b/doc/pmars.txt
@@ -285,7 +285,7 @@ REDCODE
 
        * - indirect using A-field
 
-       { - predrecement indirect using A-field
+       { - predecrement indirect using A-field
 
        } - postincrement indirect using A-field
 


### PR DESCRIPTION
Closes #19

Fixed the typo 'predrecement' → 'predecrement' in addressing mode descriptions in two documentation files:
- doc/pmars.txt (line 288)
- doc/pmars.6 (line 394)

No functional code changes.