### PR TITLE
docs: fix user intervention typo

### DIFF
--- a/doc/pmars.6
+++ b/doc/pmars.6
@@ -972,7 +972,7 @@ Several commands can be issued on one line
 when separated by the tilde character (\(ti). These "command chains" are
 useful for repeating long command sequences, since <Enter> recalls
 the entire chain (see the examples below).
-Commands requiring user intervaention
+Commands requiring user intervention
 .I (list, edit, fill)
 also read their input from the chain.
 .LP

--- a/doc/pmars.txt
+++ b/doc/pmars.txt
@@ -709,7 +709,7 @@ COMMAND CHAINS AND MACRO PROGRAMMING
        Several  commands can be issued on one line when separated by the tilde
        character (~). These "command chains" are  useful  for  repeating  long
        command  sequences,  since  <Enter>  recalls  the entire chain (see the
-       examples below).  Commands requiring user  intervaention  (list,  edit,
+       examples below).  Commands requiring user  intervention  (list,  edit,
        fill) also read their input from the chain.
 
        The  "empty  command"  (two consecutive tildes or a tilde at the end of


### PR DESCRIPTION
Fixes #18

Replaces the misspelled `intervaention` text with `intervention` in both the manpage source and the generated text output.